### PR TITLE
Python3 Cleanup

### DIFF
--- a/boot_surgeon.py
+++ b/boot_surgeon.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import pager
 import cbf
 import sys
@@ -14,7 +15,7 @@ File can be any name, but must conform to CBF standards.
     """
     pager_client = pager.client(conn_iface(mount_connection()))
     pager_client.upload(path)
-    print 'Booting surgeon.'
+    print ('Booting surgeon.')
 
 
 if len(sys.argv) != 2:

--- a/interface.py
+++ b/interface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##############################################################################
 #    OpenLFConnect
 #
@@ -31,6 +31,8 @@
 
 #@
 # services/interface.py Version 0.5
+# Ported to Python 3 by A.McCarthy
+
 class config(object):
     def __init__(self, connection):
         self._connection = connection
@@ -47,7 +49,7 @@ class config(object):
     def get_device_id(self):
         try:
             return self._connection.get_device_id_i()
-        except Exception, e:
+        except Exception as e:
             self._connection.rerror(e)
 
     device_id = property(get_device_id)
@@ -57,7 +59,7 @@ class config(object):
     def get_host_id(self):
         try:
             return self._connection.get_host_id_i()
-        except Exception, e:
+        except Exception as e:
             self._connection.rerror(e)
             
     host_id = property(get_host_id)
@@ -66,8 +68,8 @@ class config(object):
     def is_connected(self):
         try:
             return self._connection.is_connected_i()
-        except Exception, e:
+        except Exception as e:
             self._connection.rerror(e)
 
 if __name__ == '__main__':
-    print 'No examples yet.'
+    print('No examples yet.')

--- a/make_cbf.py
+++ b/make_cbf.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import cbf
 import sys
 

--- a/mount.py
+++ b/mount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##############################################################################
 #    OpenLFConnect
 #
@@ -31,6 +31,8 @@
 
 #@
 # mount.py Version 0.5.2
+# Ported to Python 3 by A.McCarthy
+
 import os
 import re
 import sys
@@ -114,13 +116,13 @@ class connection(object):
             if not err:
                 ret = p.stdout.read()
                 
-                if self._vendor_name in ret.lower():
+                if self._vendor_name in str(ret.lower(), 'utf-8'):
                     return ret
                 else:
                     return ''
             else:
                 return ''
-        except Exception, e:
+        except Exception as e:
             self.error(e)
 
 
@@ -131,7 +133,7 @@ class connection(object):
 
             while time_out:
                 if sys.platform == 'win32':
-                    lines = self.sg_scan().split('\n')
+                    lines = str(self.sg_scan(), 'utf-8').split('\n')
                     if lines:
                         for line in lines:
                             if self._vendor_name in line.lower():
@@ -168,7 +170,7 @@ class connection(object):
                 time_out -= 1
                 sleep(1)
             self.error('Device not found.')
-        except Exception, e:
+        except Exception as e:
             self.error(e)
 
 
@@ -211,7 +213,7 @@ class connection(object):
                 sleep(1)
                 timeout -= 1
             self.error('Mount not found.')
-        except Exception, e:
+        except Exception as e:
             self.error(e)
 
 
@@ -228,7 +230,7 @@ class connection(object):
     def get_device_id_i(self):
         try:
             return self._device_id or self.find_device_id()
-        except Exception, e:
+        except Exception as e:
             self.error(e)
 
 
@@ -236,7 +238,7 @@ class connection(object):
     def get_host_id_i(self):
         try:
             return self._mount_point or self.find_mount_point()
-        except Exception, e:
+        except Exception as e:
             self.error(e)
 
 
@@ -244,8 +246,8 @@ class connection(object):
     def is_connected_i(self):
         try:
             return os.path.exists(self._mount_point)
-        except Exception, e:
+        except Exception as e:
             self.error(e)
 
 if __name__ == '__main__':
-    print 'No examples yet.'
+    print('No examples yet.')

--- a/pager.py
+++ b/pager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##############################################################################
 #    OpenLFConnect
 #
@@ -31,6 +31,8 @@
 
 #@
 # pager.py Version 0.7
+# Ported to Python 3 by A.McCarthy
+
 import os
 import sys
 import struct
@@ -73,20 +75,27 @@ class client(object):
                 self.error('Surgeon not found.')
                     
             cbf.check(path)
-            buf = ''
+            buf = b''
+            packets = 0
+            
             with open(path, 'rb') as f:
                 buf = f.read()
                 f.close()
 
             buf_len = len(buf)
+            
 
             packet_leftovers = buf_len % cbf.PACKET_SIZE
+            
             if packet_leftovers > 0:
                 padding_size = cbf.PACKET_SIZE - packet_leftovers
-                buf += struct.pack('%ss' % padding_size, '\xFF'*padding_size)
+                buf += struct.pack('%ss' % padding_size, b'\xFF'*padding_size)
 
             buf_len = len(buf)
-            packets = buf_len/cbf.PACKET_SIZE
+
+            # Use of int function - should be ok as already checked in cbf to ensure buffer/packet size = whole number
+            packets = int(buf_len/cbf.PACKET_SIZE)
+            print(packets)
 
             byte1 = '00'
             total = 0
@@ -96,9 +105,10 @@ class client(object):
                 cmdl = '%s %s -b -s %s -n 2A 00 00 00 00 %s 00 00 20 00' % (self._sg_raw, self._mount_config.device_id, cbf.PACKET_SIZE, byte1)
                 cmd = shlex_split(cmdl)
                 byte1 = '01'
+                #print(cmd)
                 p = Popen(cmd, stdin=PIPE, stderr=PIPE)
                 p.stdin.write(buf[last_total:last_total+cbf.PACKET_SIZE])
-                err = p.stderr.read()
+                err = str(p.stderr.read(), 'utf-8')
                 
                 if not 'Good' in err:
                     self.error('SCSI error.')
@@ -110,15 +120,9 @@ class client(object):
             
             if len(err) != 0:
                 self.error('SCSI error.')                
-        except Exception, e:
+        except Exception as e:
             self.rerror(e)
 
 
 if __name__ == '__main__':
-    print 'No examples yet.'
-        
-
-
-
-
-    
+    print('No examples yet.')

--- a/remote_flash.sh
+++ b/remote_flash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # We use a public/private keypair to authenticate. 
 # Surgeon uses the 169.254.8.X subnet to differentiate itself from
@@ -35,8 +35,8 @@ boot_surgeon () {
   surgeon_path=$1
   memloc=$2
   echo "Booting the Surgeon environment..."
-  python2 make_cbf.py $memloc $surgeon_path surgeon_tmp.cbf
-  sudo python2 boot_surgeon.py surgeon_tmp.cbf
+  python3 make_cbf.py $memloc $surgeon_path surgeon_tmp.cbf
+  sudo python3 boot_surgeon.py surgeon_tmp.cbf
   echo -n "Done! Waiting for Surgeon to come up..."
   rm surgeon_tmp.cbf
   sleep 15
@@ -95,7 +95,7 @@ flash_nand () {
   if [[ $prefix == lf1000_* ]]; then
 	  memloc="high"
 	  kernel="zImage_tmp.cbf"
-	  python2 make_cbf.py $memloc ${prefix}zImage $kernel
+	  python3 make_cbf.py $memloc ${prefix}zImage $kernel
   else
 	  memloc="superhigh"
 	  kernel=${prefix}uImage


### PR DESCRIPTION
To make it clear, I didn't do these edits, @andymcca did in the [sshflash-win repo](https://github.com/andymcca/sshflash-win)
I'm just pushing some of the cleanup I did to make flashing RetroLeap work with python3 on my laptop.

No real code tweaks required, all worked fine on Linux with Python 3.11 to flash my LeapPad 2 (more testing with other hardware may be required)

Only four cleanup items done on my end that didn't already exist
- reverted `.exe` references back to `.py`
- Updated shebangs to reference /usr/bin/env across the board (most already had this)
- Updated python shebangs to target python3
- Updated `remote_flash.sh` to reference python3 instead of python2